### PR TITLE
Add support for per system default media

### DIFF
--- a/PinballY/BackglassView.h
+++ b/PinballY/BackglassView.h
@@ -74,6 +74,9 @@ protected:
 	virtual const MediaType *GetBackgroundVideoType() const override;
 	virtual const TCHAR *GetDefaultBackgroundImage() const override { return _T("Default Backglass"); }
 	virtual const TCHAR *GetDefaultBackgroundVideo() const override { return _T("Default Backglass"); }
+	virtual const TCHAR *GetDefaultSystemImage() const override { return _T("Default Images\\No Back Glass"); }
+	virtual const TCHAR *GetDefaultSystemVideo() const override { return _T("Default Videos\\No Back Glass"); }
+
 	virtual const TCHAR *StartupVideoName() const override { return _T("Startup Video (bg)"); }
 
 	// "show when running" window ID

--- a/PinballY/DMDView.h
+++ b/PinballY/DMDView.h
@@ -66,6 +66,8 @@ protected:
 	virtual const MediaType *GetBackgroundVideoType() const override;
 	virtual const TCHAR *GetDefaultBackgroundImage() const override { return _T("Default DMD"); }
 	virtual const TCHAR *GetDefaultBackgroundVideo() const override { return _T("Default DMD"); }
+	virtual const TCHAR *GetDefaultSystemImage() const override { return _T("Default Images\\No DMD"); }
+	virtual const TCHAR *GetDefaultSystemVideo() const override { return _T("Default Videos\\No DMD"); }
 	virtual const TCHAR *StartupVideoName() const override { return _T("Startup Video (dmd)"); }
 
 	// "show when running" window ID

--- a/PinballY/InstCardView.h
+++ b/PinballY/InstCardView.h
@@ -39,6 +39,8 @@ protected:
 	virtual void GetBackgroundImageMedia(const GameListItem *game, const MediaType *mtype, TSTRING &image) override;
 	virtual const TCHAR *GetDefaultBackgroundImage() const override { return _T("Default Instruction Card"); }
 	virtual const TCHAR *GetDefaultBackgroundVideo() const override { return _T("Default Instruction Card"); }
+	virtual const TCHAR *GetDefaultSystemImage() const override { return _T("Default Images\\No Instruction Card"); }
+	virtual const TCHAR *GetDefaultSystemVideo() const override { return _T("Default Videos\\No Instruction Card"); }
 	virtual const TCHAR *StartupVideoName() const override { return _T("Startup Video (instcard)"); }
 
 	// "show when running" window ID

--- a/PinballY/SecondaryView.cpp
+++ b/PinballY/SecondaryView.cpp
@@ -45,10 +45,17 @@ void SecondaryView::GetMediaFiles(const GameListItem *game,
 	if (auto gl = GameList::Get(); gl != nullptr)
 	{
 		TCHAR buf[MAX_PATH];
-		if (gl->FindGlobalVideoFile(buf, _T("Videos"), GetDefaultBackgroundVideo()))
+
+		const TCHAR * systemMediaDir = (system != nullptr ? game->system->mediaDir.c_str() : nullptr);
+
+		if (systemMediaDir && gl->FindGlobalVideoFile(buf, systemMediaDir, GetDefaultSystemVideo()))
+				defaultVideo = buf;
+		else if (gl->FindGlobalVideoFile(buf, _T("Videos"), GetDefaultBackgroundVideo()))
 			defaultVideo = buf;
-		
-		if (gl->FindGlobalImageFile(buf, _T("Images"), GetDefaultBackgroundImage()))
+
+		if (systemMediaDir && gl->FindGlobalImageFile(buf, systemMediaDir, GetDefaultSystemImage()))
+			defaultImage = buf;
+		else if (gl->FindGlobalImageFile(buf, _T("Images"), GetDefaultBackgroundImage()))
 			defaultImage = buf;
 	}
 }

--- a/PinballY/SecondaryView.h
+++ b/PinballY/SecondaryView.h
@@ -80,6 +80,10 @@ protected:
 	virtual const TCHAR *GetDefaultBackgroundImage() const = 0;
 	virtual const TCHAR *GetDefaultBackgroundVideo() const = 0;
 
+	// get my default system image/video name
+	virtual const TCHAR *GetDefaultSystemImage() const = 0;
+	virtual const TCHAR *GetDefaultSystemVideo() const = 0;
+
 	// Get the media files for the background for the given game
 	virtual void GetMediaFiles(const GameListItem *game,
 		TSTRING &video, TSTRING &image, TSTRING &defaultVideo, TSTRING &defaultImage);

--- a/PinballY/TopperView.h
+++ b/PinballY/TopperView.h
@@ -40,6 +40,8 @@ protected:
 	virtual const MediaType *GetBackgroundVideoType() const override;
 	virtual const TCHAR *GetDefaultBackgroundImage() const override { return _T("Default Topper"); }
 	virtual const TCHAR *GetDefaultBackgroundVideo() const override { return _T("Default Topper"); }
+	virtual const TCHAR *GetDefaultSystemImage() const override { return _T("Default Images\\No Topper"); }
+	virtual const TCHAR *GetDefaultSystemVideo() const override { return _T("Default Videos\\No Topper"); }
 	virtual const TCHAR *StartupVideoName() const override { return _T("Startup Video (topper)"); }
 
 	// "show when running" window ID


### PR DESCRIPTION
Adds support for loading default media for backglass, DMD, and Topper
based the system (VP, FP, FX2, etc.). This change was specfically
implemented to support the existing paths and filenames currently
supported by PinballX.

Files are placed in the "Default Images" or "Default Videos" subfolder
of the Media folder.  Media file names are of the format "No DMD.*",
"No back glass.*", "No Topper.*", etc.

If you are already using default system media in your PinballX media folder, this
should pick them up.