### PR TITLE
Adds options to allow views to transition in parallel

### DIFF
--- a/PinballY/Resource.h
+++ b/PinballY/Resource.h
@@ -529,6 +529,7 @@
 #define ID_FILTER_BY_CATEGORY           32816
 #define ID_MUTE_ATTRACTMODE             32817
 #define ID_PINSCAPE_NIGHT_MODE          32818
+#define ID_SYNC_ALL_VIEWS               32819
 #define ID_HIGH_SCORES                  32820
 #define ID_CLEAR_CREDITS                32821
 #define ID_GAME_SETUP                   32822

--- a/PinballY/SecondaryView.cpp
+++ b/PinballY/SecondaryView.cpp
@@ -169,6 +169,11 @@ bool SecondaryView::UpdateAnimation()
 
 void SecondaryView::SyncNextWindow()
 {
+
+	// Skip sync of Secondary Windows if parallel loading is enabled
+	if (ConfigManager::GetInstance()->GetBool(_T("LoadViewsInParallel"), false))
+		return;
+
 	if (UINT cmd = GetNextWindowSyncCommand(); cmd != 0)
 	{
 		if (auto pfv = Application::Get()->GetPlayfieldView(); pfv != nullptr)
@@ -360,7 +365,7 @@ void SecondaryView::SyncCurrentGame()
 void SecondaryView::StartBackgroundCrossfade()
 {
 	// set up the crossfade
-	DWORD crossFadeTime = 120;
+	DWORD crossFadeTime = ConfigManager::GetInstance()->GetInt(_T("SecondaryCrossfadeTime"), 120);
 	SetTimer(hWnd, animTimerID, animTimerInterval, 0);
 	incomingBackground.sprite->StartFade(1, crossFadeTime);
 }


### PR DESCRIPTION
EXPERIMENTAL:  By default, PinballY loads each view sequentially,
with playfield first, followed by Backglass, DMD, Topper, and finally
Instruction cards.  This approach results in smoother individual
transitions, as all the videos aren't trying to load at once.  The
side effect of this approach is that there is a perceptible delay
between views loading, particularly between when the playfield is
observed to load, and when the topper and instruction card are
are observed to load at the end of the sequennce.

This commit adds a "LoadViewsInParallel" config item that, when set,
will override this sequential behavior and begin loading all secondary
views in parallel as soon as the transition anmiation for the playfield
starts.  This config value defaults to false, retaining the original
behaviour if it is not set, or set to 0.

Note that this option has not been added to the in game options dialog.
To enable, you must directly add the following entry to settings.txt file:

LoadViewsInParallel = 1

This commit also adds the ability to tweak the transition times for the
playfield and secondary view fade animations. Adjusting these values can
help the timing of fades between playfield and secondary views to blend
a bit better when used in conjunction with the LoadViewsInParallel setting.

Again, these options have not been added to the in game options dialog.
To enable, you must add the following lines directly to settings.txt:

PlayfieldCrossfadeTime = 120
SecondaryCrossfadeTime = 120

These values represent the time in ms for the playfield and secondary
views to crossfade between videos or images.  If not specified, the
default setting is 120ms, retaining the exisiting transistion behavior.