### PR TITLE
RefreshFilter() updated to account for Game System

### DIFF
--- a/PinballY/GameList.cpp
+++ b/PinballY/GameList.cpp
@@ -727,8 +727,12 @@ void GameList::RefreshFilter()
 			// far - this also has the side effect of selecting the first
 			// game we encounter, so as long the new filter matches at least
 			// one game, we'll end up with something selected.
-			if (oldSel != nullptr
-				&& (curGame == -1 || IsLexicallyCloser(game->title, byTitleFiltered[curGame]->title, oldSel->title)))
+			const std::vector<GameListItem*> bTF = byTitleFiltered;
+			if (oldSel != nullptr && 
+				(curGame == -1 ||
+					IsLexicallyCloser(game->title + _T(".") + (game->system != nullptr ? game->system->displayName : _T("")), 
+						bTF[curGame]->title + _T(".") + (bTF[curGame]->system != NULL ? bTF[curGame]->system->displayName : _T("")),
+						oldSel->title + _T(".") + (oldSel->system != NULL ? oldSel->system->displayName : _T("")))))
 				curGame = idx;
 		}
 	}


### PR DESCRIPTION
When changing filters, the RefreshFilter method attempts to find
the closest lexical match to the current game selection to use
once the incoming filter is active.  The idea is that if the game
in question is included by both filters, it will still be selected by
the new filter as it should always be the closest lexical match.
However, this algorithm does not take the system associated with
the game table into consideration, and as such, if you have multiple
tables with the same name, but different systems, the first system
in the wheel list will always be selected by this algorithm, even
if another table of the same name is actually selected and also included by
the incoming filter.

This commit updates RefreshFilter to also take system into
consideration when determining which table should be selected.  This
ensures that the same table will still be selected when changing
between filters if that table is included by both filters.

This fix can also address a crash and audio glitches that can
happen during startup when metafilters are enabled and the first
game of multiple with the same name is not included in the active
filter at startup, though another fix is being rolled out to address
the root cause of this particular crash.

See GitHub issue #86 for more details.