### PR TITLE
Add ability to change weel layout parameters via Settings.txt

### DIFF
--- a/DefaultSettings.txt
+++ b/DefaultSettings.txt
@@ -958,6 +958,47 @@ StatusLine.Enable = 1
 UpperStatus.UpdateTime = 2513
 LowerStatus.UpdateTime = 2233
 
+# Wheel sizing and position. These variable adjust the sizing
+# and position of the wheel to get the layout you prefer.
+# 
+# The screen space for the wheel is in D3D space which makes
+# (0,0) is the middle of the window and (-0.5,0.5) at the top
+# left. The wheel is drawn as a circle with the center (window
+# horizontal center) at Wheel.YCenter.
+#
+#  (-0.5, 0.5) ------ ( 0.0, 0.5) ------ ( 0.5, 0.5)
+#       |                  |                 |
+#       |                  |                 |
+#       |      -x,+y       |     +x,+y       |
+#       |                  |                 |
+#  (-0.5, 0.0) ------ ( 0.0, 0.0) ------ ( 0.5, 0.0)
+#       |                  |                 |
+#       |                  |                 |
+#       |      -x,-y       |     +x,-y       |
+#       |                  |                 |
+#  (-0.5,-0.5) ------ ( 0.0,-0.5) ------ ( 0.5,-0.5)
+#
+#
+# YCenter: Vertical center of the wheel circle.
+#
+# Radius: The radius of the circle the wheel is laid out on.
+#
+# Angle: Angle between games on the wheel circle.
+#
+Wheel.YCenter = -0.803645833
+Wheel.Radius = 0.4760416667
+Wheel.Angle = 0.25
+
+#
+# ImageWidth: Width of selected wheel image. The wheel images
+# are stretched/shrunk to match this height when displayed on the
+# wheel.
+Wheel.ImageWidth = 0.14
+
+#
+# YSelected: Vertical location to place the currently selected
+# wheel image when idle (not animating).
+Wheel.YSelected = -0.07135
 
 # Enable the wheel underlay?  The underlay is an image that's 
 # displayed displayed near the bottom of the screen, in the area 

--- a/PinballY/PlayfieldView.cpp
+++ b/PinballY/PlayfieldView.cpp
@@ -190,6 +190,14 @@ namespace ConfigVars
 	static const TCHAR *UnderlayHeight = _T("Underlay.Height");
 	static const TCHAR *UnderlayYOffset = _T("Underlay.YOffset");
 	static const TCHAR *UnderlayMaxWidth = _T("Underlay.MaxWidth");
+
+	static const TCHAR *WheelXCenter = _T("Wheel.XCenter");
+	static const TCHAR *WheelYCenter = _T("Wheel.YCenter");
+	static const TCHAR *WheelRadius = _T("Wheel.Radius");
+	static const TCHAR *WheelAngle = _T("Wheel.Angle");
+	static const TCHAR *WheelImageWidth = _T("Wheel.ImageWidth");
+	static const TCHAR *WheelXSelected = _T("Wheel.XSelected");
+	static const TCHAR *WheelYSelected = _T("Wheel.YSelected");
 };
 
 // include the capture-related variables
@@ -202,11 +210,6 @@ static const DWORD wheelTime = 260;
 // the middle of the window is (0,0) and the top left is (-.5,+.5).
 // The wheel is drawn as a circle with center (window horizontal 
 // center, WHEEL_Y).
-const float WHEEL_R = 914.0f / 1920.0f;          // wheel circle radius
-const float WHEEL_Y = -1543.0f / 1920.0f;        // vertical center of wheel circle
-const float WHEEL_DTHETA = 0.25f;                // angle between games
-const float WHEEL_Y0 = -0.07135f;                // center image y offset at idle
-const float WHEEL_IMAGE_WIDTH = 0.14f;           // target width of main icon image
 const float WHEEL_TOP = -562.0f / 1920.0f;       // top of wheel area, for underlay placement
 
 // "No Command" 
@@ -8249,18 +8252,19 @@ Sprite *PlayfieldView::LoadWheelImage(const GameListItem *game)
 void PlayfieldView::SetWheelImagePos(Sprite *image, int n, float progress)
 {
 	// set the scale so that the image width comes out to the target width
-	float ratio = image->loadSize.x == 0.0f ? 1.0f : WHEEL_IMAGE_WIDTH / image->loadSize.x;
+	float ratio = image->loadSize.x == 0.0f ? 1.0f : wheel.imageWidth / image->loadSize.x;
 	image->scale.x = image->scale.y = ratio;
 
 	// calculate the angle for this game
-	float theta = float(n) * WHEEL_DTHETA;
+	float theta = float(n) * wheel.angle;
 
 	// adjust for the travel distance
-	theta -= progress * WHEEL_DTHETA * fabs(float(animWheelDistance));
+	theta -= progress * wheel.angle * fabs(float(animWheelDistance));
 
 	// calculate the new position
-	image->offset.x = WHEEL_R * sinf(theta);
-	image->offset.y = WHEEL_Y + WHEEL_R * cosf(theta);
+	image->offset.x = wheel.radius * sinf(theta);
+	image->offset.y = wheel.yCenter + wheel.radius * cosf(theta);
+	image->offset.z = 0.0f;
 
 	// For images at the center or transitioning to/from the center spot,
 	// adjust the position and scale.  The center image is shown at (0,y0)
@@ -8268,18 +8272,23 @@ void PlayfieldView::SetWheelImagePos(Sprite *image, int n, float progress)
 	// natural wheel positions at idle.  We adjust the position and scale
 	// on a ramp between the standard and special positions according to
 	// the progress.
+	// The z offset is set [0.0f ... 1.0f] with the center image at the 
+	// top (1.0) and other images below. This is used later so we can draw
+	// the center image over top of all the other images.
 	float ramp = fabs(progress)*progress*progress;
 	if (n == 0)
 	{
 		// Outgoing center image
 		image->scale.x = image->scale.y = 1.0f - (1.0f - ratio)*ramp;
-		image->offset.y = WHEEL_Y0 - (WHEEL_Y0 - image->offset.y)*ramp;
+		image->offset.y = wheel.ySelected - (wheel.ySelected - image->offset.y)*ramp;
+		image->offset.z = 1.0f - abs(progress);
 	}
 	else if (n == animWheelDistance)
 	{
 		// Animation target - incoming center image
 		image->scale.x = image->scale.y = ratio + (1.0f - ratio)*ramp;
-		image->offset.y += (WHEEL_Y0 - image->offset.y)*ramp;
+		image->offset.y += (wheel.ySelected - image->offset.y)*ramp;
+		image->offset.z = abs(progress);
 	}
 
 	// update the world transform for the image
@@ -10377,7 +10386,18 @@ void PlayfieldView::UpdateDrawingList()
 	// helps avoid this.
 	if (!attractMode.active || !attractMode.hideWheelImages)
 	{
+		// Sort the wheel images based on their z offset into a temporary
+		// list. The center (selected) image will have the highest z offset and
+		// be drawn last (on top of all other images).
+		std::list<Sprite *> sortedWheelImages;
 		for (auto& s : wheelImages)
+			sortedWheelImages.push_back(s);
+
+		sortedWheelImages.sort([](const Sprite *a, const Sprite *b) {
+			return a->offset.z < b->offset.z; 
+		});
+
+		for (auto& s : sortedWheelImages)
 			AddToDrawingList(s);
 	}
 
@@ -11879,6 +11899,18 @@ void PlayfieldView::OnConfigChange()
 
 	// topmost during launch?
 	isTopmostDuringLaunch = cfg->GetBool(ConfigVars::TopmostDuringGameLaunch, false);
+
+	// Wheel layout parameters.  Coordinates are in D3D space, where
+	// the middle of the window is (0,0) and the top left is (-.5,+.5).
+	// The wheel is drawn as a circle with center (window horizontal
+	// center, WHEEL_Y).
+	wheel.xCenter = cfg->GetFloat(ConfigVars::WheelXCenter, 0.0f);
+	wheel.yCenter = cfg->GetFloat(ConfigVars::WheelYCenter, -1543.0f / 1920.0f);
+	wheel.radius = cfg->GetFloat(ConfigVars::WheelRadius, 914.0f / 1920.0f);
+	wheel.angle = cfg->GetFloat(ConfigVars::WheelAngle, 0.25f);
+	wheel.imageWidth = cfg->GetFloat(ConfigVars::WheelImageWidth, 0.14f);
+	wheel.xSelected = cfg->GetFloat(ConfigVars::WheelXSelected, 0.0f);
+	wheel.ySelected = cfg->GetFloat(ConfigVars::WheelYSelected, -0.07135f);
 
 	// load the underlay enabled status
 	underlayEnabled = cfg->GetBool(ConfigVars::UnderlayEnable, true);

--- a/PinballY/PlayfieldView.h
+++ b/PinballY/PlayfieldView.h
@@ -1483,6 +1483,49 @@ protected:
 	bool wheelVisible = true;
 	float wheelAlpha = 1.0f;
 
+	// Wheel layout settings 
+	struct WheelOptions
+	{
+		WheelOptions() { Clear(); }
+
+		// populate from a Javascript object
+		//WheelOptions(JavascriptEngine::JsObj &options);
+
+		float xCenter;		// horizontal center of wheel circle
+		float yCenter;		// vertical center of wheel circle (WHEEL_Y)
+		float radius;		// wheel circle radius (WHEEL_R)
+		float angle;		// angle between games (WHEEL_DTHETA)
+		float imageWidth;	// target width of main icon image (WHEEL_IMAGE_WIDTH)
+		float xSelected;	// center image x location at idle
+		float ySelected;	// center image y location at idle (WHEEL_Y0)
+
+		void Clear() { xCenter = yCenter = radius = angle = imageWidth = xSelected = ySelected = INFINITY; }
+
+		bool operator==(const WheelOptions &other) const
+		{
+			return this->xCenter == other.xCenter 
+				&& this->yCenter == other.yCenter
+				&& this->radius == other.radius
+				&& this->angle == other.angle
+				&& this->imageWidth == other.imageWidth
+				&& this->xSelected == other.xSelected
+				&& this->ySelected == other.ySelected;
+		}
+
+		void ApplyDefaults(const WheelOptions &defaults)
+		{
+			// Substitute the default for each missing element (indicated
+			// by the magic value INFINITY)
+			if (xCenter == INFINITY) xCenter = defaults.xCenter;
+			if (yCenter == INFINITY) yCenter = defaults.yCenter;
+			if (radius == INFINITY) radius = defaults.radius;
+			if (angle == INFINITY) angle = defaults.angle;
+			if (imageWidth == INFINITY) imageWidth = defaults.imageWidth;
+			if (xSelected == INFINITY) xSelected = defaults.xSelected;
+			if (ySelected == INFINITY) ySelected = defaults.ySelected;
+		}
+	} wheel;
+
 	// Game info box.  This is a popup that appears when we're idling
 	// with a game selected, showing the title and other metadata for
 	// the active selection.  This box is automatically removed when


### PR DESCRIPTION
Adds the wheel radius, center location, angle of images, image size,
and location of the selected (n=0) game to Settings.txt. This allows
more tweaking of the UI.

For example, a nearly flat, bar-style wheel is now available with:

```
Wheel.Angle = 0.025
Wheel.Radius = 5.0
Wheel.YCenter = -5.25
```

NOTE: This commit adds but does not use the X coordinate settings.
NOTE: This has not been exported to the Javascript engine in any way.