### PR TITLE
Added file extension for nvram files when ROM filename is provided

### DIFF
--- a/PinballY/HighScores.cpp
+++ b/PinballY/HighScores.cpp
@@ -349,6 +349,17 @@ bool HighScores::GetNvramFile(TSTRING &nvramPath, TSTRING &nvramFile, const Game
 			// the associated .nv file.
 			if (!Valid())
 			{
+				
+				// if the name isn't empty and doesn't end in .nv, add the .nv suffix
+				// Condition for testing extension (.nv) is not strictly needed 
+				if (nvramFile.length() != 0 && !tstriEndsWith(nvramFile.c_str(), _T(".nv")))
+				{
+					nvramFile += _T(".nv");
+
+					LogFile::Get()->Write(LogFile::HiScoreLogging,
+					_T("+ The name so far doesn't end in .nv, so we're adding that -> %s\n"), nvramFile.c_str());
+				}
+				
 				// look up the lower-cased name in the friendly ROM list
 				CSTRING key = TSTRINGToCSTRING(nvramFile);
 				std::transform(key.begin(), key.end(), key.begin(), ::_tolower);


### PR DESCRIPTION
Getting high scores for Visual Pinball/VPinMAME doesn't work that well. Multiple ROM names mean nothing is chosen. One way to resolve this is to explicitly provide the ROM name in the table setup. However the ".nv" file extension is not added by the code and so the NMRAM file with the scores is still not found. 

This fix copies some code from further down that adds the file extension. Although not done here, it might be better to change the code structure so that looking for the ROM filename is separate from the last part that adds the ".nv" file extension and looks up the high scores.

This code was tested with the TOTAN ROM that has at least two ROM files (totan_12.zip and totan_14.zip).