### PR TITLE
Add settings for vertical wheel display (XCenter, XSelected, OffsetAngle)

### DIFF
--- a/DefaultSettings.txt
+++ b/DefaultSettings.txt
@@ -425,7 +425,7 @@ RunAtExit =
 # window showing basic information on the game.  These settings control
 # whether the box is shown at all, and if so, which items it displays.
 #
-# InfoBox.Show -> controls whehtehr or not the box is shown at all
+# InfoBox.Show -> controls whether or not the box is shown at all
 # .Title -> include the game's title in the box
 # .GameLogo -> use the game's logo graphics in place of the title, when available
 # .Manufacturer -> show the manufacturer name
@@ -1085,15 +1085,20 @@ Wheel.AutoRepeatRate =
 #  (-0.5,-0.5) ------ ( 0.0,-0.5) ------ ( 0.5,-0.5)
 #
 #
+# XCenter: Horizontal center of the wheel circle.
+#
 # YCenter: Vertical center of the wheel circle.
 #
 # Radius: The radius of the circle the wheel is laid out on.
 #
 # Angle: Angle between games on the wheel circle.
-#
+# 
+# OffsetAngle: Starting angle of the wheel in radians
+
 Wheel.YCenter = -0.803645833
 Wheel.Radius = 0.4760416667
 Wheel.Angle = 0.25
+Wheel.OffsetAngle = 0.0
 
 #
 # ImageWidth: Width of selected wheel image. The wheel images
@@ -1105,6 +1110,10 @@ Wheel.ImageWidth = 0.14
 # YSelected: Vertical location to place the currently selected
 # wheel image when idle (not animating).
 Wheel.YSelected = -0.07135
+
+# XSelected: Horizontal location to place the currently selected
+# wheel image when idle (not animating).
+Wheel.XSelected = 0
 
 # Enable the wheel underlay?  The underlay is an image that's 
 # displayed displayed near the bottom of the screen, in the area 

--- a/Help/WheelLayout.html
+++ b/Help/WheelLayout.html
@@ -56,11 +56,13 @@
 
    <li><b>Wheel.YCenter:</b>  The vertical position (in the D3D coordinate
    system described above) of the <b>center of the circle</b> that defines
-   the wheel.  (The wheel is always centered in the window left-to-right,
-   so there's no "XCenter" parameter.)  The default is -0.803645833,
-   which is below the bottom of the window by about half the window's
-   height; this positions the visible portion of the wheel in the bottom
-   third of the window.
+   the wheel. The default is -0.803645833,  which is below the bottom of
+   the window by about half the window's height; this positions the visible
+   portion of the wheel in the bottom third of the window.
+    
+   <li><b>Wheel.XCenter:</b>  The horizontal position (in the D3D coordinate
+   system described above) of the <b>center of the circle</b> that defines
+   the wheel. The default is 0.0, which is centered in the window.
 
    <li><b>Wheel.Radius:</b>  The radius of the wheel's overall circle, in
    terms of the height of the window.  A radius of 1.0 makes the wheel's
@@ -78,6 +80,9 @@
    a range where you'd only see those five anyway.  It might look
    odd if you leave too much empty space at the sides.</p>
 
+   <li><b>Wheel.OffsetAngle:</b> The angular position of the currently
+    selected game in <b>radians</b>.
+
    <li><b>Wheel.ImageWidth:</b>  The width of the wheel icon for the
    center (selected) game, in D3D horizontal units.  The icons are
    scaled to this width, maintaining the original aspect ratio of
@@ -85,11 +90,19 @@
 
    <li><b>Wheel.YSelected:</b>  The vertical location (in D3D coordinates)
    for the current selected game's icon.  The icon is centered on this
-   position vertically (and is centered in the window horizontally).
+   position vertically.
    This variable lets you move the current game's icon away from the
    wheel arc, to give it a more prominent placement closer to the center
    of the screen.  The default is -0.07135, which is slightly below the
    vertical center of the window.
+
+   <li><b>Wheel.XSelected:</b>  The horizontal location (in D3D coordinates)
+   for the current selected game's icon.  The icon is centered on this
+   position horizontally.
+   This variable lets you move the current game's icon away from the
+   wheel arc, to give it a more prominent placement closer to the center
+   of the screen.  The default is 0, which is horizontally centered
+   on the window.
 
 </ul>
 

--- a/PinballY/PlayfieldView.h
+++ b/PinballY/PlayfieldView.h
@@ -1549,6 +1549,7 @@ protected:
 		float yCenter;		// vertical center of wheel circle (WHEEL_Y)
 		float radius;		// wheel circle radius (WHEEL_R)
 		float angle;		// angle between games (WHEEL_DTHETA)
+		float offsetAngle;	// wheel start rotation
 		float imageWidth;	// target width of main icon image (WHEEL_IMAGE_WIDTH)
 		float xSelected;	// center image x location at idle
 		float ySelected;	// center image y location at idle (WHEEL_Y0)
@@ -1574,6 +1575,7 @@ protected:
 			if (yCenter == INFINITY) yCenter = defaults.yCenter;
 			if (radius == INFINITY) radius = defaults.radius;
 			if (angle == INFINITY) angle = defaults.angle;
+			if (offsetAngle == INFINITY) offsetAngle = defaults.offsetAngle;
 			if (imageWidth == INFINITY) imageWidth = defaults.imageWidth;
 			if (xSelected == INFINITY) xSelected = defaults.xSelected;
 			if (ySelected == INFINITY) ySelected = defaults.ySelected;

--- a/PinballY/PlayfieldView.h
+++ b/PinballY/PlayfieldView.h
@@ -1562,6 +1562,7 @@ protected:
 				&& this->yCenter == other.yCenter
 				&& this->radius == other.radius
 				&& this->angle == other.angle
+				&& this->offsetAngle == other.offsetAngle
 				&& this->imageWidth == other.imageWidth
 				&& this->xSelected == other.xSelected
 				&& this->ySelected == other.ySelected;


### PR DESCRIPTION
I was curious about having a vertical wheel display, and this seemed like a reasonable set of changes.

## New options

* `XCenter`: A horizontal wheel center, matching `YCenter`
* `XSelected`: Horizontal position of the selected wheel image, matching `YSelected`
* `OffsetAngle`: The currently selected game's rotational position on the wheel in radians

Other changes:

* Doc and comment updates where appropriate
* Handful of space-indented lines in Playfield.cpp converted to tabs for consistency
* Typo in DefaultSettings.txt

I think this will work best with wheel images that are all the same size/aspect ratio.

![PinballY_E9TaINuFUG](https://github.com/mjrgh/PinballY/assets/242008/1a50cf19-976c-4863-8435-085e482901c3)

Future improvements could include [additional control over the info box position and size](https://github.com/mjrgh/PinballY/pull/220), and direct controls or limits on size of the currently selected wheel image.