### PR TITLE
Fix unresponsive scrolling due to crossfade

### DIFF
--- a/PinballY/PlayfieldView.cpp
+++ b/PinballY/PlayfieldView.cpp
@@ -5240,8 +5240,15 @@ void PlayfieldView::ProcessKeyPress(
 	// of the animation on any new key-down event.  This makes the
 	// UI more responsive by not forcing the user to wait through 
 	// each wheel animation step.
-	if (mode == KeyPressType::KeyDown && wheelAnimMode == WheelAnimMode::WheelAnimNormal)
-		wheelAnimStartTime = GetTickCount64() - wheelTime;
+	if (mode == KeyPressType::KeyDown) {
+		if (wheelAnimMode == WheelAnimMode::WheelAnimNormal)
+			wheelAnimStartTime = GetTickCount64() - wheelTime;
+
+		// also skip to the end of ongoing playfield crossfade
+		if (incomingPlayfield.sprite != 0 && !incomingPlayfield.sprite->IsFadeDone()) {
+			incomingPlayfield.sprite->EndFade();
+		}
+	}
 
 	// process the command queue
 	ProcessKeyQueue();

--- a/PinballY/SecondaryView.cpp
+++ b/PinballY/SecondaryView.cpp
@@ -271,7 +271,7 @@ void SecondaryView::SyncCurrentGame()
 		game = gl->GetNthGame(0);
 	}
 
-	// fill in the syncer watchdog with the seleted game
+	// fill in the syncer watchdog with the selected game
 	syncer.game = game;
 
 	// Fire the "begin media sync" event
@@ -296,6 +296,8 @@ void SecondaryView::SyncCurrentGame()
 
 	// reset paged/indexed images to the first item
 	currentImageIndex = 0;
+
+	EndAnimation();
 
 	// load the current game's media
 	syncer.loadStarted = LoadCurrentGameMedia(game, true);
@@ -469,6 +471,15 @@ void SecondaryView::StartBackgroundCrossfade()
 	DWORD crossFadeTime = pfv != nullptr ? pfv->GetCrossfadeTime() : 120;
 	SetTimer(hWnd, animTimerID, animTimerInterval, 0);
 	incomingBackground.sprite->StartFade(1, crossFadeTime);
+}
+
+void SecondaryView::EndAnimation()
+{
+	if (incomingBackground.sprite != nullptr && !incomingBackground.sprite->IsFadeDone()) {
+		incomingBackground.sprite->EndFade();
+		incomingBackground.sprite->UpdateFade();
+		UpdateAnimation();
+	}
 }
 
 void SecondaryView::OnEnableVideos(bool enable)

--- a/PinballY/SecondaryView.h
+++ b/PinballY/SecondaryView.h
@@ -23,6 +23,8 @@ public:
 	// sync with the current selection in the global game list
 	void SyncCurrentGame();
 
+	void EndAnimation();
+
 	// update our menu
 	virtual void UpdateMenu(HMENU hMenu, BaseWin *fromWin) override;
 

--- a/PinballY/Sprite.cpp
+++ b/PinballY/Sprite.cpp
@@ -1867,6 +1867,14 @@ float Sprite::UpdateFade()
 	return alpha;
 }
 
+void Sprite::EndFade()
+{
+	if (fadeDir != 0)
+	{
+		fadeStartTime = GetTickCount() - fadeDuration;
+	}
+}
+
 bool Sprite::IsFadeDone(bool reset)
 {
 	// stash the result

--- a/PinballY/Sprite.h
+++ b/PinballY/Sprite.h
@@ -111,6 +111,9 @@ public:
 	// has the last fade completed?
 	bool IsFadeDone(bool reset = FALSE);
 
+	// end the current fade early
+	void EndFade();
+
 	// update our world transform for a change in offset, rotation, or scale
 	void UpdateWorld();
 


### PR DESCRIPTION
## Issue description

When scrolling through games, slow enough to trigger the crossfade effect, repeated key presses will be deferred until the end of the current animation. At the default crossfade time of 120ms, this is still pretty noticeable and doesn't feel great (imo).

## Proposed solution

On user input, immediately end the current fade transition and start the next one.

This is already done on master, but is limited to the wheel animation only, so input is still blocked/delayed until the end of the crossfade.

Here are two examples with the crossfade time set to a huge 3000ms to exaggerate the impact. Excuse the missing/misnamed media etc.

## Before

https://github.com/mjrgh/PinballY/assets/242008/82ca7420-6a19-49aa-b79a-25c09a1e547f

## After

https://github.com/mjrgh/PinballY/assets/242008/9c7b27df-31c2-4380-b976-b3a35b1e1d2b


