### PR TITLE
Fix for z-order of overlapping wheel images

### DIFF
--- a/PinballY/PlayfieldView.cpp
+++ b/PinballY/PlayfieldView.cpp
@@ -9631,7 +9631,7 @@ void PlayfieldView::SetWheelImagePos(Sprite *image, int n, float progress)
 	// calculate the new position
 	image->offset.x = wheel.radius * sinf(theta);
 	image->offset.y = wheel.yCenter + wheel.radius * cosf(theta);
-	image->offset.z = 0.0f;
+	image->offset.z = 3.0f - fabs(n - progress);
 
 	// For images at the center or transitioning to/from the center spot,
 	// adjust the position and scale.  The center image is shown at (0,y0)
@@ -9648,14 +9648,12 @@ void PlayfieldView::SetWheelImagePos(Sprite *image, int n, float progress)
 		// Outgoing center image
 		image->scale.x = image->scale.y = 1.0f - (1.0f - ratio)*ramp;
 		image->offset.y = wheel.ySelected - (wheel.ySelected - image->offset.y)*ramp;
-		image->offset.z = 1.0f - abs(progress);
 	}
 	else if (n == animWheelDistance)
 	{
 		// Animation target - incoming center image
 		image->scale.x = image->scale.y = ratio + (1.0f - ratio)*ramp;
 		image->offset.y += (wheel.ySelected - image->offset.y)*ramp;
-		image->offset.z = abs(progress);
 	}
 
 	// update the world transform for the image
@@ -9773,6 +9771,7 @@ void PlayfieldView::SwitchToGame(int n, bool fast, bool byUserCommand, bool fire
 
 		// make sure it's off the screen initially
 		s->offset.y = -5.0f;
+		s->offset.z = 0.0f;
 		s->scale.x = s->scale.y = 0.0f;
 		s->UpdateWorld();
 


### PR DESCRIPTION
Fixes the z-order of the list image in the wheel. Mostly relevant when wheel radius is smaller and/or wheel angle is low so that overlap is more visible.

## Before (from master)

https://github.com/mjrgh/PinballY/assets/242008/7816e8dd-530f-43ca-bd90-1a7728acecf3

## After

https://github.com/mjrgh/PinballY/assets/242008/33e6b4e6-4ba3-4f1e-8402-59667a5d36a7

