### PR TITLE
Add RotateImages setting to rotate wheel images based on wheel position

### DIFF
--- a/DefaultSettings.txt
+++ b/DefaultSettings.txt
@@ -1090,10 +1090,13 @@ Wheel.AutoRepeatRate =
 # Radius: The radius of the circle the wheel is laid out on.
 #
 # Angle: Angle between games on the wheel circle.
+# 
+# RotateImages: Whether game images should be rotated to match their wheel position
 #
 Wheel.YCenter = -0.803645833
 Wheel.Radius = 0.4760416667
 Wheel.Angle = 0.25
+Wheel.RotateImages = 0
 
 #
 # ImageWidth: Width of selected wheel image. The wheel images

--- a/Help/WheelLayout.html
+++ b/Help/WheelLayout.html
@@ -78,6 +78,10 @@
    a range where you'd only see those five anyway.  It might look
    odd if you leave too much empty space at the sides.</p>
 
+   <li><b>Wheel.RotateImages:</b></li> Whether wheel icons should be
+    rotated based on their position on the wheel. The selected image 
+    will have no rotation applied. The default is 0.
+
    <li><b>Wheel.ImageWidth:</b>  The width of the wheel icon for the
    center (selected) game, in D3D horizontal units.  The icons are
    scaled to this width, maintaining the original aspect ratio of

--- a/PinballY/PlayfieldView.cpp
+++ b/PinballY/PlayfieldView.cpp
@@ -201,6 +201,7 @@ namespace ConfigVars
 	static const TCHAR *WheelYCenter = _T("Wheel.YCenter");
 	static const TCHAR *WheelRadius = _T("Wheel.Radius");
 	static const TCHAR *WheelAngle = _T("Wheel.Angle");
+	static const TCHAR* WheelRotateImages = _T("Wheel.RotateImages");
 	static const TCHAR *WheelImageWidth = _T("Wheel.ImageWidth");
 	static const TCHAR *WheelXSelected = _T("Wheel.XSelected");
 	static const TCHAR *WheelYSelected = _T("Wheel.YSelected");
@@ -9633,6 +9634,9 @@ void PlayfieldView::SetWheelImagePos(Sprite *image, int n, float progress)
 	image->offset.y = wheel.yCenter + wheel.radius * cosf(theta);
 	image->offset.z = 0.0f;
 
+	if (wheel.rotateImages) {
+		image->rotation.z = -theta;
+	}
 	// For images at the center or transitioning to/from the center spot,
 	// adjust the position and scale.  The center image is shown at (0,y0)
 	// and at scale factor 1.0; the adjacent images are shown at their
@@ -13576,6 +13580,7 @@ void PlayfieldView::OnConfigChange()
 	wheel.yCenter = cfg->GetFloat(ConfigVars::WheelYCenter, -1543.0f / 1920.0f);
 	wheel.radius = cfg->GetFloat(ConfigVars::WheelRadius, 914.0f / 1920.0f);
 	wheel.angle = cfg->GetFloat(ConfigVars::WheelAngle, 0.25f);
+	wheel.rotateImages = cfg->GetBool(ConfigVars::WheelRotateImages, false);
 	wheel.imageWidth = cfg->GetFloat(ConfigVars::WheelImageWidth, 0.14f);
 	wheel.xSelected = cfg->GetFloat(ConfigVars::WheelXSelected, 0.0f);
 	wheel.ySelected = cfg->GetFloat(ConfigVars::WheelYSelected, -0.07135f);

--- a/PinballY/PlayfieldView.h
+++ b/PinballY/PlayfieldView.h
@@ -1549,6 +1549,7 @@ protected:
 		float yCenter;		// vertical center of wheel circle (WHEEL_Y)
 		float radius;		// wheel circle radius (WHEEL_R)
 		float angle;		// angle between games (WHEEL_DTHETA)
+		bool rotateImages;	// whether wheel images are rotated during navigation
 		float imageWidth;	// target width of main icon image (WHEEL_IMAGE_WIDTH)
 		float xSelected;	// center image x location at idle
 		float ySelected;	// center image y location at idle (WHEEL_Y0)
@@ -1561,6 +1562,7 @@ protected:
 				&& this->yCenter == other.yCenter
 				&& this->radius == other.radius
 				&& this->angle == other.angle
+				&& this->rotateImages == other.rotateImages
 				&& this->imageWidth == other.imageWidth
 				&& this->xSelected == other.xSelected
 				&& this->ySelected == other.ySelected;


### PR DESCRIPTION
Add `RotateImages` setting to individually rotate wheel images based on wheel position.

## Example

https://github.com/mjrgh/PinballY/assets/242008/1902fa1c-c306-4897-a0ce-caf46a6fb763

Also looks nice with vertical wheels from #216