### PR TITLE
Support recursive table folder layout

### DIFF
--- a/PinballY/Application.cpp
+++ b/PinballY/Application.cpp
@@ -5954,7 +5954,7 @@ DWORD Application::NewFileScanThread::Main()
 	{
 		// Scan this folder for files matching the extension for this set
 		const TCHAR *ext = d.ext.c_str();
-		TableFileSet::ScanFolder(d.path.c_str(), d.ext.c_str(), [&d](const TCHAR *filename)
+		TableFileSet::ScanFolder(d.path.c_str(), d.path.c_str(), d.ext.c_str(), [&d](const TCHAR *filename)
 		{
 			// make the key by converting the name to lower-case
 			TSTRING key(filename);

--- a/PinballY/GameList.h
+++ b/PinballY/GameList.h
@@ -1202,7 +1202,7 @@ public:
 
 	// Enumerate files in a folder matching an extension.  If the
 	// extension is null or empty, no files match.
-	static void ScanFolder(const TCHAR *path, const TCHAR *ext, 
+	static void ScanFolder(const TCHAR* basepath, const TCHAR *path, const TCHAR *ext,
 		std::function<void(const TCHAR *filename)> func);
 
 	TSTRING tablePath;		// full path to the system's table folder


### PR DESCRIPTION
For VPX, on other platforms than Windows, the 'standard' table layout if to have a folder per table that includes all other files (b2s, pupvideos, cache, music, user folder, pinmame rom and nvram, flex/ultraDMD, ...). This also allows to deploy table as a bundle on device where file management is less easy like mobile phones.

The next version of VPX will bring this layout to Windows (still supporting the existing 'flat' layout where all table files are messed up together).

This PR change the way PinballY process table folders: with it, it will scan the folder as of today, but also scans subdirectory recursively and includes the table found oin these subfolders into the system table list. It also adapts how the default table name is evaluated to account for that (dropping the sub folder name).