### PR TITLE
Fix out-of-memory crash when loading large animated PNGs

### DIFF
--- a/PinballY/PinballY.vcxproj
+++ b/PinballY/PinballY.vcxproj
@@ -99,6 +99,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
+      <LargeAddressAware>true</LargeAddressAware>
       <AdditionalDependencies>..\VersionInfoUpdater\bin\$(Platform)_$(Configuration)\VersionInfo.obj;$(OutDir)Utilities.lib;$(SolutionDir)$(Platform)\$(Configuration)\litehtml.lib;..\DirectXTK\bin\Desktop_2017\$(Configuration)\$(Platform)\DirectXTK.lib;..\DirectXTK\Audio\bin\Desktop_2017_DXSDK\$(Platform)\$(Configuration)\DirectXTKAudioDX.lib;..\DirectXTex\DirectXTex\Bin\Desktop_2017\$(Platform)\$(Configuration)\DirectXTex.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <MinimumRequiredVersion>
@@ -170,6 +171,7 @@ echo $(SolutionDir)&gt; "$(OutDir).DevEnvironment
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <SubSystem>Windows</SubSystem>
+      <LargeAddressAware>true</LargeAddressAware>
       <AdditionalDependencies>..\VersionInfoUpdater\bin\$(Platform)_$(Configuration)\VersionInfo.obj;$(OutDir)Utilities.lib;$(SolutionDir)$(Platform)\$(Configuration)\litehtml.lib;..\DirectXTK\bin\Desktop_2017\$(Configuration)\$(Platform)\DirectXTK.lib;..\DirectXTK\Audio\bin\Desktop_2017_DXSDK\$(Platform)\$(Configuration)\DirectXTKAudioDX.lib;..\DirectXTex\DirectXTex\Bin\Desktop_2017\$(Platform)\$(Configuration)\DirectXTex.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <AdditionalLibraryDirectories>%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <MinimumRequiredVersion>

--- a/PinballY/Sprite.cpp
+++ b/PinballY/Sprite.cpp
@@ -375,7 +375,7 @@ bool Sprite::LoadAPNG(const WCHAR *filename, POINTF normalizedSize, SIZE pixSize
 	// set up to load frames on demand.  If not, we'll simply fall back
 	// on the generic WIC loader, to attempt to load the file as a
 	// contentional single-frame PNG or some other image type.
-	std::unique_ptr<APNGLoaderState> loader(new APNGLoaderState());
+	std::unique_ptr<APNGLoaderState> loader(new APNGLoaderState(pixSize));
 	if (loader->Init(this, filename, normalizedSize, pixSize))
 	{
 		// create the mesh
@@ -433,13 +433,22 @@ bool Sprite::APNGLoaderState::Init(Sprite *sprite, const WCHAR *filename, POINTF
 
 	// Read the first frame.  If decoding fails, or the PNG file doesn't
 	// have the added chunks that make it an APNG, abort and use the
-	// standard WIC loader.
-	if (!ReadThroughNextFrame() || !isAnimated)
-		return false;
+	// standard WIC loader.  A decoding exception (such as an allocation
+	// failure on an oversized image) counts as a decoding failure.
+	try
+	{
+		if (!ReadThroughNextFrame() || !isAnimated)
+			return false;
 
-	// Create first snimation frame
-	if (!CreateAnimFrame(sprite->loadContext))
+		// Create first snimation frame
+		if (!CreateAnimFrame(sprite->loadContext))
+			return false;
+	}
+	catch (std::exception &exc)
+	{
+		LogFile::Get()->Write(_T("APNG: exception decoding first frame (%hs); falling back to static image loader\n"), exc.what());
 		return false;
+	}
 
 	// success
 	return true;
@@ -448,8 +457,27 @@ bool Sprite::APNGLoaderState::Init(Sprite *sprite, const WCHAR *filename, POINTF
 void Sprite::APNGLoaderState::DecodeNext(LoadContext *ctx)
 {
 	// read through the next frame
-	if (!eof && ReadThroughNextFrame())
-		CreateAnimFrame(ctx);
+	//
+	// This runs during rendering, so on an allocation failure mid-decode,
+	// we stop the animation gracefully rather than letting the exception
+	// crash the app.
+	try
+	{
+		if (!eof && ReadThroughNextFrame())
+		{
+			// If the frame can't be created - a texture error, or the
+			// animation reached its texture memory budget - stop decoding,
+			// and loop over the frames we already have.  Retrying on every
+			// rendering pass would just prolong the memory pressure.
+			if (!CreateAnimFrame(ctx))
+				eof = true;
+		}
+	}
+	catch (std::exception &exc)
+	{
+		LogFile::Get()->Write(_T("APNG: exception decoding frame (%hs); stopping animation\n"), exc.what());
+		eof = true;
+	}
 }
 
 bool Sprite::APNGLoaderState::CreateAnimFrame(LoadContext *ctx)
@@ -458,18 +486,75 @@ bool Sprite::APNGLoaderState::CreateAnimFrame(LoadContext *ctx)
 	if (frameCur.data == nullptr)
 		return false;
 
+	// Figure the frame's texture size.  We keep every frame resident as a
+	// texture for the duration of the animation, so a full-resolution
+	// multi-frame APNG can exhaust the address space.  There's no point in
+	// storing more pixels than the sprite's on-screen size, so downscale
+	// oversized frames to the target pixel size, or to a fixed default if
+	// the caller didn't provide a size.
+	LONG longestTarget = max(targetPixSize.cx, targetPixSize.cy);
+	UINT maxEdge = longestTarget > 0 ? static_cast<UINT>(longestTarget) : 512;
+	UINT texW = frameCur.width, texH = frameCur.height;
+	if (frameCur.width > maxEdge || frameCur.height > maxEdge)
+	{
+		UINT longEdge = max(frameCur.width, frameCur.height);
+		double s = static_cast<double>(maxEdge) / longEdge;
+		texW = max(static_cast<UINT>(frameCur.width * s), 1U);
+		texH = max(static_cast<UINT>(frameCur.height * s), 1U);
+	}
+
+	// Cap the total animation texture memory; when the cap is reached, stop
+	// decoding and loop over the frames we already have.  Always allow the
+	// first frame, so that there's at least a static image to display.  Do
+	// this before the resampling step below, so that we don't waste the
+	// resampling work on a frame we're only going to discard.
+	const size_t maxTexBytes = 64 * 1024 * 1024;
+	const size_t frameBytes = static_cast<size_t>(texW) * texH * 4;
+	if (!ctx->animFrames.empty() && loadedTexBytes + frameBytes > maxTexBytes)
+	{
+		LogFile::Get()->Write(_T("APNG: %u MB texture budget reached after %u frame(s); ")
+			_T("capping animation to avoid exhausting memory\n"),
+			(unsigned)(maxTexBytes / (1024 * 1024)), (unsigned)ctx->animFrames.size());
+		return false;
+	}
+
+	// downscale the frame if we selected a reduced size above
+	const BYTE *texData = frameCur.data.get();
+	UINT texPitch = frameCur.width * 4;
+	DirectX::ScratchImage scaled;   // owns the downscaled pixels while we upload
+	if (texW != frameCur.width || texH != frameCur.height)
+	{
+		// high-quality resample via DirectXTex (already a project dependency)
+		DirectX::Image srcImg;
+		ZeroMemory(&srcImg, sizeof(srcImg));
+		srcImg.width = frameCur.width;
+		srcImg.height = frameCur.height;
+		srcImg.format = DXGI_FORMAT_R8G8B8A8_UNORM;
+		srcImg.rowPitch = static_cast<size_t>(frameCur.width) * 4;
+		srcImg.slicePitch = srcImg.rowPitch * frameCur.height;
+		srcImg.pixels = frameCur.data.get();
+		if (FAILED(DirectX::Resize(srcImg, texW, texH, DirectX::TEX_FILTER_FANT, scaled)))
+		{
+			// resize failed (e.g. out of memory)
+			return false;
+		}
+		const DirectX::Image *out = scaled.GetImage(0, 0, 0);
+		texData = out->pixels;
+		texPitch = static_cast<UINT>(out->rowPitch);
+	}
+
 	// set up the D3D texture descriptor
 	D3D11_TEXTURE2D_DESC txd = CD3D11_TEXTURE2D_DESC(
-		DXGI_FORMAT_R8G8B8A8_UNORM, frameCur.width, frameCur.height, 1, 1,
+		DXGI_FORMAT_R8G8B8A8_UNORM, texW, texH, 1, 1,
 		D3D11_BIND_SHADER_RESOURCE, D3D11_USAGE_DYNAMIC, D3D11_CPU_ACCESS_WRITE,
 		1, 0, 0);
 
 	// set up the subresource descriptor
 	D3D11_SUBRESOURCE_DATA srd;
 	ZeroMemory(&srd, sizeof(srd));
-	srd.pSysMem = frameCur.data.get();
-	srd.SysMemPitch = frameCur.width * 4;
-	srd.SysMemSlicePitch = srd.SysMemPitch * frameCur.height;
+	srd.pSysMem = texData;
+	srd.SysMemPitch = texPitch;
+	srd.SysMemSlicePitch = texPitch * texH;
 
 	// set up the shader resource view
 	D3D11_SHADER_RESOURCE_VIEW_DESC svd;
@@ -504,6 +589,8 @@ bool Sprite::APNGLoaderState::CreateAnimFrame(LoadContext *ctx)
 		// return failure
 		return false;
 	}
+
+	loadedTexBytes += frameBytes;
 
 	// success
 	return true;

--- a/PinballY/Sprite.h
+++ b/PinballY/Sprite.h
@@ -46,7 +46,9 @@ public:
 	// size is used to determine the rasterization size for vector 
 	// graphic media (e.g., Flash objects).  It's ignored for raster
 	// images (e.g., JPEG, PNG), which are loaded at the native size
-	// for the media.
+	// for the media, with one exception: animated PNG frames larger
+	// than the pixel size are downscaled to fit it, to limit the
+	// memory needed to keep all of the frame textures resident.
 	//
 	// msgHwnd is a window that will receive AVPxxx messages related
 	// to animation playback, if desired.  This can be null if these
@@ -469,6 +471,8 @@ protected:
 	// frame at a time on demand.
 	struct APNGLoaderState : Animation
 	{
+		APNGLoaderState(SIZE targetPixSize) : targetPixSize(targetPixSize) { }
+
 		// Animation interface implementation
 		virtual ~APNGLoaderState() { EndProcessing(); }
 		virtual void DecodeNext(LoadContext *ctx) override;
@@ -675,8 +679,21 @@ protected:
 		// do we have the IDAT frame yet?
 		bool hasIDAT = false;
 
-		// have we reached EOF?
+		// have we reached EOF?  (This is also set to end decoding early,
+		// on a frame decoding error or on reaching the animation's
+		// texture memory budget.)
 		bool eof = false;
+
+		// Target on-screen size of the sprite, in pixels.  Frames larger
+		// than this are downscaled to this size when creating the frame
+		// textures, since there's no point in keeping more pixels resident
+		// than the display can show.
+		SIZE targetPixSize;
+
+		// Running total of the memory used for the animation frame textures,
+		// in bytes.  We stop decoding new frames when this reaches a fixed
+		// budget, to keep a long animation from exhausting memory.
+		size_t loadedTexBytes = 0;
 
 		// number of fcTL records we've encountered so far
 		int fcTLCount = 0;


### PR DESCRIPTION
The APNG loader keeps every decoded frame resident as a D3D texture, so a large multi-frame APNG can exhaust the 32-bit address space and crash.

- Downscale frames larger than the sprite's on-screen size (DirectXTex FANT, already linked)
- Cap per-animation texture memory at 64MB; when reached, stop decoding and loop the loaded frames (first frame always kept)
- Catch decode exceptions: fall back to the static WIC loader at load time, stop the animation mid-render

Second commit (drop if unwanted): link the Win32 build /LARGEADDRESSAWARE.

Repro case: animated wheel-image APNGs (500x500, 16-149 frames, 1-29 MB each, e.g. Deadpool 149 frames, Attack from Mars 90 frames). With a dozen such wheel images plus backglass/DMD/table videos, the 32-bit build runs out of address space while scrolling the game wheel.

Verified on a 3-monitor cab (14 animated wheel APNGs + full video media): process virtual size exceeded 2GB during normal scrolling (LAA kept it alive), and the >67-frame APNGs hit the 64MB cap and loop the loaded frames as designed, logged as "APNG: 64 MB texture budget reached after 67 frame(s)".

Notes: frames are sized for the largest on-screen state, so no visible change in normal use. The 64MB constant could be a setting if you'd prefer. The GIF loader shares this design and could get the same treatment.

Suggested version note: Fixed an out-of-memory crash when loading large animated PNG files.