### PR TITLE
Two small cleanups in the media capture path

### DIFF
--- a/PinballY/Application.cpp
+++ b/PinballY/Application.cpp
@@ -5095,6 +5095,14 @@ DWORD Application::GameMonitorThread::Main()
 					statusList.Error(MsgFmt(_T("%s: %s"), itemDesc.c_str(), MsgFmt(IDS_ERR_CAP_ITEM_FFMPEG_LAUNCH, err.Get()).Get()));
 					captureOkay = false;
 					abortCapture = true;
+
+					// Delete the ffmpeg output temp file.  On a successful launch,
+					// CopyOutputToLog deletes it after copying it to the log, but
+					// we won't get that far on this path.  Close our file handle
+					// first so that the delete can succeed.
+					hStdOut = nullptr;
+					if (fnameStdOut.length() != 0)
+						DeleteFile(fnameStdOut.c_str());
 				}
 
 				// add a blank line to the log after the FFMPEG output, for readability 

--- a/Utilities/AudioCapture.cpp
+++ b/Utilities/AudioCapture.cpp
@@ -15,9 +15,7 @@ void EnumDirectShowAudioInputDevices(std::function<bool(const AudioCaptureDevice
 	// create the audio device enumerator
 	RefPtr<ICreateDevEnum> pCreateDevEnum;
 	RefPtr<IEnumMoniker> pEnumMoniker;
-	LPMALLOC coMalloc = nullptr;
-	if (SUCCEEDED(CoGetMalloc(1, &coMalloc))
-		&& SUCCEEDED(CoCreateInstance(CLSID_SystemDeviceEnum, NULL, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&pCreateDevEnum)))
+	if (SUCCEEDED(CoCreateInstance(CLSID_SystemDeviceEnum, NULL, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&pCreateDevEnum)))
 		&& pCreateDevEnum->CreateClassEnumerator(CLSID_AudioInputDeviceCategory, &pEnumMoniker, 0) == S_OK
 		&& pEnumMoniker != nullptr)
 	{


### PR DESCRIPTION
Two minor issues found by code review of the capture path:

- EnumDirectShowAudioInputDevices (Utilities/AudioCapture.cpp) calls CoGetMalloc for an IMalloc it never uses and never releases. Removed the call. (This is an unbalanced AddRef on the process-wide task allocator, so it leaks a refcount rather than memory - harmless in practice, but dead code either way.)

- In the capture loop (Application.cpp), the temp file created for ffmpeg output is only deleted by CopyOutputToLog on the successful-launch path; when CreateProcess fails to launch ffmpeg, the PBYCap*.tmp file is left behind in %TEMP%. Now deleted in the failure branch too.

Neither of these explains the batch-capture memory exhaustion in #154 - for that, /LARGEADDRESSAWARE in #281 is the more relevant change, since the 32-bit build has only 2GB of address space for capture-sized workloads.