### PR TITLE
Fix null dereference when a function is reused as a dllImport callback

### DIFF
--- a/PinballY/JavascriptEngine.cpp
+++ b/PinballY/JavascriptEngine.cpp
@@ -4175,11 +4175,12 @@ void JavascriptEngine::MarshallToNative::DoPointer()
 			JavascriptCallbackWrapper *wrapper = nullptr;
 			if (hasThunk)
 			{
-				// retrieve and validate the external data
+				// Retrieve and validate the external data, capturing the recovered
+				// wrapper - it's the source of the thunk we pass to the caller below
 				const TCHAR *where = nullptr;
-				if (!JavascriptCallbackWrapper::Recover<JavascriptCallbackWrapper>(thunk, where))
+				if ((wrapper = JavascriptCallbackWrapper::Recover<JavascriptCallbackWrapper>(thunk, where)) == nullptr)
 				{
-					Error(err, MsgFmt(_T("dllImport: recovering callback function thunk data: %s"), where));
+					Error(MsgFmt(_T("dllImport: recovering callback function thunk data: %s"), where));
 					return;
 				}
 			}


### PR DESCRIPTION
`MarshallToNative::DoPointer()` (JsFunction case) discards the wrapper recovered from the function's callback thunk property, leaving `wrapper` null for `Store(wrapper->thunk)` at the end of the block. The first use of a function object as a callback works (create-new-thunk path); any later use of the **same function object** takes the `hasThunk` path and crashes with an access violation. The stale `err` passed to `Error()` on that path is also dropped, since `Recover()` failure isn't a `JsErrorCode`.

## Repro

Run this as `main.js` (the key detail is the reused named function — a fresh arrow function each call doesn't reproduce):

```js
dllImport.define(`typedef BOOL (CALLBACK *WNDENUMPROC)(HWND hwnd, LPARAM lParam);`);
let User32 = dllImport.bind("User32.dll", `
    HWND WINAPI GetDesktopWindow();
    BOOL WINAPI EnumChildWindows(HWND hwnd, WNDENUMPROC lpEnumFunc, LPARAM lParam);
`);

function onWindow(hwnd, lParam) { return true; }
let desktop = User32.GetDesktopWindow();

User32.EnumChildWindows(desktop, onWindow, 0);   // pass 1: ok
logfile.log("pass 1 ok");
User32.EnumChildWindows(desktop, onWindow, 0);   // pass 2: crashes unpatched
logfile.log("pass 2 ok");
```

Unpatched: "pass 1 ok" is the last log line, then the process dies with 0xc0000005. Patched: both passes log and enumeration works.

Verified on Windows 11, x86 and x64 release builds.