### PR TITLE
Add DrawingLayer.setRotation() to the scripting API

### DIFF
--- a/PinballY/BaseView.cpp
+++ b/PinballY/BaseView.cpp
@@ -915,6 +915,9 @@ void BaseView::ScaleDrawingLayerSprite(JsDrawingLayer &l)
 {
 	if (auto s = l.sprite.Get(); s != nullptr)
 	{
+		// apply the layer rotation before the fit calc below reads s->rotation.z
+		s->rotation.z = l.rotation;
+
 		// Figure the window's width in terms of its height.  The
 		// window's height in normalized sprite units is fixed at 1.0,
 		// so this is the same as figuring the width in normalized
@@ -1455,6 +1458,22 @@ void BaseView::JsDrawingLayerSetScale(JsValueRef self, JavascriptEngine::JsObj s
 			exc.Log(_T("DrawingLayer.setScale()"));
 			js->Throw(exc.jsErrorCode, _T("DrawingLayer.setScale()"));
 		}
+	}
+}
+
+void BaseView::JsDrawingLayerSetRotation(JsValueRef self, float degrees)
+{
+	float radians = degrees * (3.14159265358979f / 180.0f);
+	if (auto l = JsThisToDrawingLayer(self); l != nullptr)
+	{
+		l->rotation = radians;
+		ScaleDrawingLayerSprite(*l);
+	}
+	else if (auto s = JsThisToDrawingLayerSprite(self); s != nullptr)
+	{
+		// sprite-backed system layer (e.g. launch overlay): no JsDrawingLayer to fit
+		s->rotation.z = radians;
+		s->UpdateWorld();
 	}
 }
 

--- a/PinballY/BaseView.h
+++ b/PinballY/BaseView.h
@@ -410,6 +410,9 @@ protected:
 			float span = 1.0f;
 		} scaling;
 
+		// rotation angle in radians (ScaleDrawingLayerSprite factors it into the fit)
+		float rotation = 0.0f;
+
 		// DMD-style message graphics are generated asynchronously
 		// in a background thread.  When we have a threaded request
 		// outstanding, we remember the sequence number of the request
@@ -437,6 +440,7 @@ protected:
 	float JsDrawingLayerGetAlpha(JsValueRef self) const;
 	void JsDrawingLayerSetAlpha(JsValueRef self, float alpha);
 	void JsDrawingLayerSetScale(JsValueRef self, JavascriptEngine::JsObj scale);
+	void JsDrawingLayerSetRotation(JsValueRef self, float degrees);
 	void JsDrawingLayerSetPos(JsValueRef self, float x, float y, WSTRING align);
 	void JsDrawingLayerPlay(JsValueRef self);
 	void JsDrawingLayerPause(JsValueRef self);

--- a/PinballY/PlayfieldView.cpp
+++ b/PinballY/PlayfieldView.cpp
@@ -1413,6 +1413,8 @@ bool PlayfieldView::InitJsWinObj(FrameWin *frame, JsValueRef jswinobj, const CHA
 			&BaseView::JsDrawingLayerClear, view, eh)
 		|| !js->DefineObjMethod(drawingLayerProto, "DrawingLayer", "setScale",
 			&BaseView::JsDrawingLayerSetScale, view, eh)
+		|| !js->DefineObjMethod(drawingLayerProto, "DrawingLayer", "setRotation",
+			&BaseView::JsDrawingLayerSetRotation, view, eh)
 		|| !js->DefineObjMethod(drawingLayerProto, "DrawingLayer", "setPos",
 			&BaseView::JsDrawingLayerSetPos, view, eh)
 		|| !js->DefineGetterSetter(drawingLayerProto, "DrawingLayer", "alpha",


### PR DESCRIPTION
## Summary
Adds `setRotation(degrees)` to the `DrawingLayer` scripting object, alongside the existing `setScale()` / `setPos()`.

## Motivation
Drawing layers can be scaled and positioned but not rotated. On a rotated cabinet (a playfield window with `MediaRotation`), a script-driven layer — e.g. a custom launch/loading overlay that plays per-game video — renders at the wrong orientation relative to the normal game media, and there's no scripting hook to correct it.

## Implementation
The sprite backing each layer already carries `rotation.z`, and `Sprite::UpdateWorld()` already applies it, so the change is small:

- **Standard drawing layers:** store the angle on the layer and re-fit via `ScaleDrawingLayerSprite()`, whose fit math already accounts for the sprite's rotation (so the layer keeps filling the window).
- **Sprite-backed system layers** (the launch overlay's `fg`/`bg`, which map to a sprite rather than a `JsDrawingLayer`): rotate the sprite in place.

```js
mainWindow.launchOverlay.bg.loadVideo(path);
mainWindow.launchOverlay.bg.setRotation(180);   // match a rotated playfield
```

3 files, +25 lines.

## Testing
Built Release|x64 and verified on a physical cabinet (rotated 4K playfield): a per-game launch video that previously rendered flipped now renders upright and fills the playfield after a `setRotation()` call. Standard drawing layers rotate and stay correctly fitted.